### PR TITLE
Improve range of compatible syntaxes, add simple hoisting support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+package-lock.json

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# 1.1.3
+
+- *Bug*: `export class` and `export function` statements would not leave a
+  definition in the module's own namespace
+
 # 1.1.2
 
 - Outer `require()` now returns at a time when all internal dependency

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,25 @@
+# 1.1.0
+
+- *Incompatible change*: you no longer use `.ns` on export lines, instead you
+  get the exported namespace object directly. As a result, you also can no
+  longer export a name of `_bridge`.
+
+# 1.0.2
+
+- First release as forked _eximport_
+- Support doublequotes (`"`) on import lines
+- Support backquotes (```) on import lines
+- Support exporting multiple names in one statement (`export {A, B}`)
+- Support `as` on import (`import {A as _A} ...`)
+- Support `import *`
+- Support `import "foo"` (side-effect only)
+- Support `export {A, B} from "foo"`
+- Support exporting multiple names in `export var` and similar
+- Avoid adding any export code if no exports have been found
+- Reorganised export work into a single bridge object (`eximport-bridge`)
+- Added basic validation of exported names
+- Improved support for quotes
+
+# 1.0.0 - 1.0.1
+
+- Earlier releases (of _import-export_)...

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# 1.1.2
+
+- Outer `require()` now returns at a time when all internal dependency
+  resolution is complete, ie. all symbols will be finally defined unless the
+  calling script is itself part of a mutual dependency loop
+
 # 1.1.1
 
 - *Bug*: if one exportable file was included and required another, the promise

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# 2.0.0
+
+- Rewrite to use generators instead of promises. This means that there should in
+  general be no reason to use `._bridge` in an outer `require()` any more
+  because all symbols should be resolved automatically by the time they're used.
+
 # 1.1.3
 
 - *Bug*: `export class` and `export function` statements would not leave a

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# 1.1.1
+
+- *Bug*: if one exportable file was included and required another, the promise
+  for the first would never fire and the namespace for the first past the
+  relevant `import` would appear on the second.
+
 # 1.1.0
 
 - *Incompatible change*: you no longer use `.ns` on export lines, instead you

--- a/README.md
+++ b/README.md
@@ -84,6 +84,26 @@ Or in async context:
 const foo = await require("foo")._bridge
 ```
 
+In any case, where this happens the immediate context will not have a defined
+value for the datum in question. As with mutual `require()`, you should change
+such expressions to be computed on demand, eg. rather than:
+
+```
+import {b} from "./b"
+export var a = b + 1
+```
+
+You should:
+
+```
+import {b} from "./b"
+export function a() {return b + 1}
+```
+
+This will operate differently - it will require to be called rather than just
+evaluated - but at any time which is not in itself in the middle of mutual
+dependency resolution it'll have a resolved value.
+
 ## How this works
 
 At a simple level, `import {Foo} from "./foo"` is the same as `var Foo =

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ e.g. you might have an `index.js` like:
 ```
 require("eximport")
 
-require("./src/foo")
+module.exports = require("./src/foo").ns
 ```
 
 ...and a `src/foo.js` like:
@@ -35,6 +35,19 @@ class Bar {
 }
 export default Bar
 ```
+
+## Return from require()
+
+This returns an anonymous object with keys:
+
+* importer: A function that finishes off imports which were incomplete, eg. due
+  to loops. This isn't usually necessary to call manually.
+* ns: The namespace object, containing all named exports and any default export
+  (called "default" if present)
+
+When you're using require() with an import/export module, you may either want to
+expose the whole namespace (`require(...).ns`), just the default
+(`require(...).ns.default`) or a specific named export (`require(...).ns.Foo`)
 
 ## Notes/bugs
 

--- a/README.md
+++ b/README.md
@@ -72,10 +72,11 @@ consider reporting it if the code in question isn't pathological.
 ### Cyclic Dependencies
 
 Any engine-embedded module support will defer some elements of evaluation of
-module A while module B is loaded - for example if you have `class Foo extends
-Bar` in one file, and `class Bar {} class Baz extends Foo` in another, and
-really the only way to handle that is to have `Foo` and `Baz` as incomplete
-classes which will become complete after all dependent evaluations are complete.
+module A while module B is loaded - for example if you have
+`class Foo extends Bar` in one file, and `class Bar {} class Baz extends Foo` in
+another, and really the only way to handle that is to have `Foo` and `Baz` as
+incomplete classes which will become complete after all dependent evaluations
+are complete.
 
 Any cyclic dependency which would have to be evaluted immediately (including all
 top-level code) won't work because of the complexity of expressing this,

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ e.g. you might have an `index.js` like:
 ```
 require("eximport")
 
-module.exports = require("./src/foo").ns
+module.exports = require("./src/foo")
 ```
 
 ...and a `src/foo.js` like:
@@ -41,8 +41,8 @@ export default Bar
 This returns an EximportBridge object.
 
 When you're using require() with an import/export module, you may either want to
-expose the whole namespace (`require(...).ns`), just the default
-(`require(...).ns.default`) or a specific named export (`require(...).ns.Foo`)
+expose the whole namespace (`require(...)`), just the default
+(`require(...).default`) or a specific named export (`require(...).Foo`)
 
 ## Notes/bugs & Known Limitations
 

--- a/README.md
+++ b/README.md
@@ -1,46 +1,41 @@
-## What is this?
+# eximport
 
-This module lets you use ES6 modules (import/export syntax) in nodejs modules.
+This module brings support for ECMAScript 6 import/export statements to your projects.
 
 This was forked from the unmaintained `import-export` module.
 
-## How to use
+## Usage
 
-In your main file require the module:
+In your top-level .js file require this module before your other project
+includes. Node's module loader will be hooked to rewrite both `import` and
+`export` statements into mutually compatible wrappers.
 
-```
-// index.js
-
-require('import-export');
-
-require('./some-other-file1.js');
-require('./some-other-file2.js');
-...
-```
-
-Then inside your other files you require you can use ES6 module syntax:
+e.g. you might have an `index.js` like:
 
 ```
-// some-other-file1.js
+require("eximport")
 
-import Duck from './Duck.js';
-import { Food, Pond } from 'Duck.js';
+require("./src/foo")
 ```
 
-and:
+...and a `src/foo.js` like:
 
 ```
-// Duck.js
+import Bar from "./bar"
+Bar.baz()
+```
 
-export default class Duck {
-  ...
+...and a `src/bar.js` like:
+
+```
+class Bar {
+  static baz() {
+    console.log("Hello World")
+  }
 }
+export default Bar
+```
 
-export class Pond {
-  ...
-}
+## Notes/bugs
 
-export class Food {
-  ...
-}
-``` 
+This cannot modify the file it's required in.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
-##What is this?
+## What is this?
 
 This module lets you use ES6 modules (import/export syntax) in nodejs modules.
 
-##How to use
+This was forked from the unmaintained `import-export` module.
+
+## How to use
 
 In your main file require the module:
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,44 @@ When you're using require() with an import/export module, you may either want to
 expose the whole namespace (`require(...).ns`), just the default
 (`require(...).ns.default`) or a specific named export (`require(...).ns.Foo`)
 
-## Notes/bugs
+## Notes/bugs & Known Limitations
+
+### Self-modifying
 
 This cannot modify the file it's required in.
+
+### Complex Expressions
+
+Due to the use of regexps, complex expressions won't be parseable. For example,
+you might want to write:
+
+```
+export var foo=`export var bar=${baz.join(",") + `}`}`
+```
+
+That's simply not going to work unless the filter has a full understanding of
+Javascript syntax and the ability to parse recursively, which isn't possible in
+regular expressions. If you've got expressions like that, just split them into a
+plain export (which eximport can handle) and the relevant assignment/expression
+(which the Javascript engine can handle).
+
+You might in some cases have a non-export/non-import expression which is picked
+up as an export or import - if so, that's an unknown bug, and you should
+consider reporting it if the code in question isn't pathological.
+
+### Cyclic Dependencies
+
+Any engine-embedded module support will defer some elements of evaluation of
+module A while module B is loaded - for example if you have `class Foo extends
+Bar` in one file, and `class Bar {} class Baz extends Foo` in another, and
+really the only way to handle that is to have `Foo` and `Baz` as incomplete
+classes which will become complete after all dependent evaluations are complete.
+
+Any cyclic dependency which would have to be evaluted immediately (including all
+top-level code) won't work because of the complexity of expressing this,
+particularly where top-level object definitions will be present in both cases.
+
+Later evaluations are worked around by dropping an empty `var` in then updating
+it once loaded. As a result, evaluation of a module might not be complete
+immediately from the perspective of the caller if there's a dependency cycle
+which includes the caller.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,33 @@ When you're using require() with an import/export module, you may either want to
 expose the whole namespace (`require(...)`), just the default
 (`require(...).default`) or a specific named export (`require(...).Foo`)
 
+## Resolving Non-Immediate Evaluation
+
+Under some circumstances, evaluation might not complete in the current execution
+context, for example this may happen where there's a mutual dependency between
+two files. If this is the case, you might get some symbols defined immediately
+and some later. If this comes up, you can call `.then(...)` on the bridge
+object, eg:
+
+```
+var foo = require("foo")
+foo._bridge.then(resolved_ns => foo = resolved_ns)
+```
+
+This will reassign the namespace once it's available. If you prefer to have no
+namespace at all until it's resolved, you can do:
+
+```
+var foo
+require("foo")._bridge.then(ns => foo = ns)
+```
+
+Or in async context:
+
+```
+const foo = await require("foo")._bridge
+```
+
 ## Notes/bugs & Known Limitations
 
 ### Self-modifying

--- a/README.md
+++ b/README.md
@@ -79,6 +79,47 @@ Or in async context:
 const foo = await require("foo")._bridge
 ```
 
+## How this works
+
+At a simple level, `import {Foo} from "./foo"` is the same as `var Foo =
+require("./foo").Foo`. Unfortunately it's not quite that simple because "export"
+hoists (its names exist before the code delaring them is executed), which is
+very valuable when you have circular references but needs to be emulated here.
+
+Instead, the code `import {Foo} from "./foo"` becomes roughly:
+
+```
+var Foo = require("./foo").Foo // Original line position
+// Other code before the main script run starts...
+Foo = require("./foo").Foo
+```
+
+This means that we can fill in the namespace entry early and then before
+anything really uses it we can insert the final value. Specifically, we can do
+that as soon as the exporting module body execution finishes.
+
+The initial "var" line has to appear at its original (presumably top) level; by
+doing so it inserts an entry directly into the correct namespace. It won't work
+inside a function. Once the name exists, plain assignment in any scope which
+inherits the original namespace is fine, so the second half is done via a
+callback function. It doesn't make sense to do a second assingment once the
+module's evaluation is complete, so at that point the callback handler is
+dummied out and any pending callbacks executed.
+
+On the exporting side, `export Foo` becomes roughly:
+
+```
+module.exports.Foo = null
+// Other module code...
+module.exports.Foo = Foo // Original line position
+// Other module code...
+```
+
+This ensures that the names all exist before any other code's import returns,
+and sets the correct value once it's known. It's necessary to do this in two
+stages because only one type of value has both its declaration and value
+hoisted: explicitly named functions.
+
 ## Notes/bugs & Known Limitations
 
 ### Self-modifying

--- a/README.md
+++ b/README.md
@@ -38,12 +38,7 @@ export default Bar
 
 ## Return from require()
 
-This returns an anonymous object with keys:
-
-* importer: A function that finishes off imports which were incomplete, eg. due
-  to loops. This isn't usually necessary to call manually.
-* ns: The namespace object, containing all named exports and any default export
-  (called "default" if present)
+This returns an EximportBridge object.
 
 When you're using require() with an import/export module, you may either want to
 expose the whole namespace (`require(...).ns`), just the default

--- a/README.md
+++ b/README.md
@@ -54,11 +54,16 @@ expose the whole namespace (`require(...)`), just the default
 
 ## Resolving Non-Immediate Evaluation
 
-Under some circumstances, evaluation might not complete in the current execution
-context, for example this may happen where there's a mutual dependency between
-two files. If this is the case, you might get some symbols defined immediately
-and some later. If this comes up, you can call `.then(...)` on the bridge
-object, eg:
+You might have noticed with `require()` that where _a_ contains `require("b")`
+and _b_ contains `require("a")`, the second one to get loaded gets the value of
+`module.exports` at that time when its corresponding `require()` appeared. In
+other words, mutual dependencies mean temporarily incomplete imports. This
+package still uses `require` so the same rules apply.
+
+In practice, this means that immediate evaluation where mutual `import`s are
+present won't work - but runtime evaluation generally will.
+
+If you get into this situation with a file which `require()`s a file which uses `export`, you can call `.then(...)` on the bridge object, eg:
 
 ```
 var foo = require("foo")

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This module brings support for ECMAScript 6 import/export statements to your pro
 
 This was forked from the unmaintained `import-export` module.
 
+
+
 ## Usage
 
 In your top-level .js file require this module before your other project

--- a/README.md
+++ b/README.md
@@ -1,10 +1,16 @@
 # eximport
 
-This module brings support for ECMAScript 6 import/export statements to your projects.
+This module brings support for ECMAScript 6 import/export statements to your
+projects.
 
-This was forked from the unmaintained `import-export` module.
+This was forked from the unmaintained `import-export` package.
 
-
+This exists because Node itself does not support ES6 modules currently - see
+https://nodejs.org/api/esm.html - but the functionality is useful if for little
+more reason than that it's more terse. If/when Node gets production es6 module
+support this package will become redundant and probably stop being maintained,
+because more complicated scenarios absolutely require that you can rearrange the
+AST.
 
 ## Usage
 

--- a/index.js
+++ b/index.js
@@ -145,7 +145,7 @@ hook.hook('.js', (src, name) => {
 
   src = src.replace(/\bexport default +/g, () => {
     exports_seen++
-    return 'module.exports.ns.default = '
+    return 'module.exports.ns.default='
   })
 
   var late_exports = [];

--- a/index.js
+++ b/index.js
@@ -103,7 +103,7 @@ hook.hook('.js', (src, name) => {
     /\bexport [*] from (["'])(.*?)\1/g,
     (a, $1, $2) => {
       exports_seen++
-      return `require("${$2}").then(ns=>Object.assign(module.exports.ns,ns,{default:module.exports.ns.default}))`
+      return `module.exports.exportFrom(require("${$2}"))`
     },
   )
   src = src.replace(
@@ -111,10 +111,10 @@ hook.hook('.js', (src, name) => {
     (all, $1, $2, $3) => {
       exports_seen++
       const names = identifierList($1)
-      return `require("${$3}").then(ns=>{` +
+      return `module.exports.exportFrom(require("${$3}"),{` +
         Object.keys(names).map(
-          name => `module.exports.ns.${name}=ns.${names[name]}`
-        ).join(";") +
+          name => `"${name}":"${names[name]}"`
+        ).join(",") +
         `})`
     }
   )

--- a/index.js
+++ b/index.js
@@ -103,40 +103,40 @@ hook.hook(".js", (src, name) => {
 
   src = src
     .replace(
-      /\bimport ([a-zA-Z0-9_$]+?), {([^{]*?)} from ((["']).*?\4)/g,
+      /\bimport ([a-zA-Z0-9_$]+?), {([^{]*?)} from ((["'`]).*?\4)/g,
       `import $1 from $3;import {$2} from $3`
     )
     .replace(
-      /\bimport ([a-zA-Z0-9_$]+?), [*] as ([a-zA-Z0-9_$]+?) from ((["']).*?\4)/g,
+      /\bimport ([a-zA-Z0-9_$]+?), [*] as ([a-zA-Z0-9_$]+?) from ((["'`]).*?\4)/g,
       `import $1 from $3;import * as $2 from $3`
     )
     .replace(
-      /\bimport [*] as ([a-zA-Z0-9_$]+?) from ((["']).*?\3)/g,
+      /\bimport [*] as ([a-zA-Z0-9_$]+?) from ((["'`]).*?\3)/g,
       `var $1;require($2).then(ns=>$1=ns)`
     )
     .replace(
-      /\bimport ([a-zA-Z0-9_$]+?) from ((["']).*?\3)/g,
+      /\bimport ([a-zA-Z0-9_$]+?) from ((["'`]).*?\3)/g,
       `import {default as $1} from $2`
     )
     .replace(
-      /\bimport {([^{]*?)} from ((["']).*?\3)/g,
+      /\bimport {([^{]*?)} from ((["'`]).*?\3)/g,
       (all, $1, $2, $3) => new IdentifierList($1).importAllFrom($2)
     )
     .replace(
-      /\bimport ((["']).*?\2)/g,
+      /\bimport ((["'`]).*?\2)/g,
       `require($1)`
     )
   let exports_seen = 0
 
   src = src.replace(
-    /\bexport [*] from ((["']).*?\2)/g,
+    /\bexport [*] from ((["'`]).*?\2)/g,
     (a, $1, $2) => {
       exports_seen++
       return `module.exports.exportFrom(require(${$1}))`
     },
   )
   src = src.replace(
-    /\bexport [{]([^{]*?)[}] from ((["']).*?\3)/g,
+    /\bexport [{]([^{]*?)[}] from ((["'`]).*?\3)/g,
     (all, $1, $2, $3) => {
       exports_seen++
       return new IdentifierList($1).exportAllFrom($2)

--- a/index.js
+++ b/index.js
@@ -61,16 +61,16 @@ hook.hook('.js', (src, name) => {
    * map of names from the given file.
    *
    * @param {string} file
-   * @param {object} dest_to_src
+   * @param {{[local_name: string]: string}} dest_to_src
    * @return {string}
    */
   function importAll(file, dest_to_src) {
-    return `var ${Object.keys(dest_to_src).join(",")};` +
-    `require("${file}").then(ns=>{` +
-    Object.keys(dest_to_src).map(dest =>
-      `${dest}=ns.${dest_to_src[dest]}`
-    ).join(";") +
-    `})`
+    const local_names = Object.keys(dest_to_src)
+    const invalid_names = local_names.filter(n => !n.match(/^\w+$/))
+    if(invalid_names.length) {
+      throw new Error(`Invalid import name(s): ${invalid_names}`)
+    }
+    return `var ${local_names.join(",")};require("${file}").then(ns=>{${local_names.map(dest => `${dest}=ns.${dest_to_src[dest]}`).join(";")}})`
   }
 
   src = src.replace(

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ hook.hook(".js", (src, name) => {
         )
         .replace(
             /\bimport [*] as ([a-zA-Z0-9_$]+?) from ((["'`]).*?\3)/g,
-            `var $1;require($2).then(ns=>$1=ns)`
+            `var $1;require($2)._bridge.then(ns=>$1=ns)`
         )
         .replace(
             /\bimport ([a-zA-Z0-9_$]+?) from ((["'`]).*?\3)/g,
@@ -73,7 +73,7 @@ hook.hook(".js", (src, name) => {
     src = src
         .replace(
             /\bexport [*] from ((["'`]).*?\2)/g,
-            (a, $1, $2) => exporting(`eximportBridge.exportFrom(require(${$1}))`)
+            (a, $1, $2) => exporting(`eximportBridge.exportFrom(require(${$1})._bridge)`)
         )
         .replace(
             /\bexport [{]([^{]*?)[}] from ((["'`]).*?\3)/g,
@@ -118,7 +118,7 @@ hook.hook(".js", (src, name) => {
             (all, $1) => exporting(new IdentifierList($1).exportAll())
         )
     if(exports_seen) {
-        return `eximportBridge=require("eximport-bridge").bridge;module.exports=eximportBridge;${src}\neximportBridge.commit({${late_exports.map(n => `${n}:${n}`).join(",")}});`
+        return `eximportBridge=require("eximport-bridge").bridge;module.exports=eximportBridge.ns;${src}\neximportBridge.commit({${late_exports.map(n => `${n}:${n}`).join(",")}});`
     } else {
         return src
     }

--- a/index.js
+++ b/index.js
@@ -1,7 +1,11 @@
 var hook = require('node-hook');
 
 hook.hook('.js', (src, name) => {
-  src = src.replace(/import ([^{]*?) from (["'])(.*?)\2/g, 'const $1 = require("$3")');
+  var seen_names = {};
+  src = src.replace(/import ([^{]*?) from (["'])(.*?)\2/g, (all, $1, $2, $3) => {
+    seen_names[$1.trim()] = $3;
+    return `imported["${$3}"] = require("${$3}")`;
+  });
   src = src.replace(/export default ([^ ]*)/g, 'module.exports = $1');
   src = src.replace(/export (var|let|const) ([a-zA-Z0-9_$]*)/g, '$1 $2 = module.exports.$2');
   src = src.replace(/export function ([a-zA-Z0-9_$]*)/g, 'var $1 = module.exports.$1 = function');
@@ -10,9 +14,14 @@ hook.hook('.js', (src, name) => {
     return $1.split(/,/).map(name => `module.exports.${name.trim()} = ${name.trim()}`).join(";");
   });
   src = src.replace(/import {(.*?)} from (["'])(.*?)\2/g, (all, $1, $2, $3) => {
-    return $1.split(",")
-      .map(part => 'var ' + part + '= require("' + $3 + '").' + part.trim() + ';')
-      .join('');
+    $1.split(",").forEach(name => {
+        seen_names[name.trim()] = $3;
+    });
+    return `imported["${$3}"] = require("${$3}")`;
   });
-  return src;
+  // Ultimately we want AST parsing but this will work in most cases.
+  Object.keys(seen_names).forEach(name => {
+    src = src.replace(new RegExp(`\\b${name}\\b`, "g"), `imported["${seen_names[name]}"].${name}`)
+  });
+  return "var imported = {};" + src;
 });

--- a/index.js
+++ b/index.js
@@ -4,20 +4,22 @@ hook.hook('.js', (src, name) => {
   var seen_names = {};
   src = src.replace(/\bimport ([^{]*?) from (["'])(.*?)\2/g, (all, $1, $2, $3) => {
     seen_names[$1.trim()] = $3;
-    return `imported["${$3}"] = require("${$3}")`;
+    return `imported["${$3}"] = require("${$3}").ns`;
   });
-  src = src.replace(/\bexport default +/g, 'module.exports = ');
-  src = src.replace(/\bexport (var|let|const) ([a-zA-Z0-9_$]*)/g, '$1 $2 = module.exports.$2');
-  src = src.replace(/\bexport function ([a-zA-Z0-9_$]*)/g, 'var $1 = module.exports.$1 = function');
-  src = src.replace(/\bexport class ([a-zA-Z0-9_$]*)/g, 'var $1 = module.exports.$1 = class');
+  src = src.replace(/\bexport default +/g, 'module.exports.ns = ');
+  src = src.replace(/\bexport (var|let|const) ([a-zA-Z0-9_$]*)/g, '$1 $2 = module.exports.ns.$2');
+  src = src.replace(/\bexport function ([a-zA-Z0-9_$]*)/g, 'var $1 = module.exports.ns.$1 = function');
+  src = src.replace(/\bexport class ([a-zA-Z0-9_$]*)/g, 'var $1 = module.exports.ns.$1 = class');
   src = src.replace(/\bexport {(.*?)}/g, (all, $1) => {
-    return $1.split(/,/).map(name => `module.exports.${name.trim()} = ${name.trim()}`).join(";");
-  });
+    var names = $1.split(/,/);
+    return names.map(
+        name => `module.exports.ns.${name.trim()} = ${names[name.trim()]}`
+    ).join(";");
   src = src.replace(/\bimport {(.*?)} from (["'])(.*?)\2/g, (all, $1, $2, $3) => {
     $1.split(",").forEach(name => {
         seen_names[name.trim()] = $3;
     });
-    return `imported["${$3}"] = require("${$3}")`;
+    return `imported["${$3}"] = require("${$3}").ns`;
   });
   // Ultimately we want AST parsing but this will work in most cases.
   Object.keys(seen_names).forEach(name => {

--- a/index.js
+++ b/index.js
@@ -3,41 +3,10 @@ const hook = require("node-hook")
 const IdentifierList = require("./lib/identifier-list")
 
 hook.hook(".js", (src, name) => {
-    /* How this works:
-    *
-    * At a simple level, `import {Foo} from "./foo"` is the same as
-    * `var Foo = require("./foo").Foo`. Unfortunately it's not quite that simple because
-    * "export" hoists (its names exist before the code delaring them is executed), which is
-    * very valuable when you have circular references but needs to be emulated here.
-    *
-    * Instead, the code `import {Foo} from "./foo"` becomes roughly:
-    *
-    *     var Foo = require("./foo").Foo; // Original line position
-    *     // Other code before the main script run starts...
-    *     Foo = require("./foo").Foo;
-    *
-    * This means that we can fill in the namespace entry early and then before anything really
-    * uses it we can insert the final value. Specifically, we can do that as soon as the
-    * exporting module body execution finishes.
-    *
-    * The initial "var" line has to appear at its original (presumably top) level; by doing so
-    * it inserts an entry directly into the correct namespace. It won't work inside a function.
-    * Once the name exists though, and plain assignment in any scope which inherits the
-    * original namespace is fine, so the second half is done via a callback function. It
-    * doesn't make sense to do a second assingment once the module's evaluation is complete, so
-    * at that point the callback handler is dummied out and any pending callbacks executed.
-    *
-    * On the exporting side, `export Foo` becomes:
-    *
-    *     module.exports.Foo = null;
-    *     // Other module code...
-    *     module.exports.Foo = Foo; // Original line position
-    *     // Other module code...
-    *
-    * This ensures that the names all exist before any other code's import returns, and sets
-    * the correct value once it's known. It's necessary to do this in two stages because only
-    * one type of value has both its declaration and value hoisted: explicitly named functions.
-    */
+    /* This modifies the source of your included Javascript files so that any
+     * import/export statements become require(). See the accompanying README
+     * for details.
+     */
 
     src = src
         .replace(

--- a/index.js
+++ b/index.js
@@ -101,12 +101,12 @@ hook.hook('.js', (src, name) => {
     ).join(";");
   });
   if(src.match(/\bmodule.exports\b/)) {
-    return "var importers = []; " +
-      "module.exports.ns = {}; " +
-      "module.exports.importer = f => importers.push(f);" +
+    return "var importers=[];" +
+      "module.exports.ns={};" +
+      "module.exports.importer=f=>importers.push(f);" +
       src + "\n" +
-      "module.exports.importer = f => f(module.exports.ns);" +
-      "importers.forEach(f => f(module.exports.ns));";
+      "module.exports.importer=f=>f(module.exports.ns);" +
+      "importers.forEach(f=>f(module.exports.ns));";
   } else {
     return src;
   }

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ class IdentifierList {
     this.destToSrc = {}
     for(const identifier of identifier_list.split(/,/)) {
       let md
-      if(md = identifier.match(/(\w+) as (\w+)/)) {
+      if(md = identifier.match(/([a-zA-Z0-9_$]+) as ([a-zA-Z0-9_$]+)/)) {
         this.add(md[2], md[1])
       } else {
         this.add(identifier.trim(), identifier.trim())
@@ -27,10 +27,10 @@ class IdentifierList {
    * @throws
    */
   add(local_name, remote_name) {
-    if(!local_name.match(/^\w+$/)) {
+    if(!local_name.match(/^[a-zA-Z0-9_$]+$/)) {
       throw new Error(`Invalid import name: ${local_name}`)
     }
-    if(!remote_name.match(/^\w+$/)) {
+    if(!remote_name.match(/^[a-zA-Z0-9_$]+$/)) {
       throw new Error(`Invalid export name: ${remote_name}`)
     }
     this.destToSrc[local_name] = remote_name
@@ -103,19 +103,19 @@ hook.hook(".js", (src, name) => {
 
   src = src
     .replace(
-      /\bimport (\w+?), {([^{]*?)} from ((["']).*?\4)/g,
+      /\bimport ([a-zA-Z0-9_$]+?), {([^{]*?)} from ((["']).*?\4)/g,
       `import $1 from $3;import {$2} from $3`
     )
     .replace(
-      /\bimport (\w+?), [*] as (\w+?) from ((["']).*?\4)/g,
+      /\bimport ([a-zA-Z0-9_$]+?), [*] as ([a-zA-Z0-9_$]+?) from ((["']).*?\4)/g,
       `import $1 from $3;import * as $2 from $3`
     )
     .replace(
-      /\bimport [*] as (\w+?) from ((["']).*?\3)/g,
+      /\bimport [*] as ([a-zA-Z0-9_$]+?) from ((["']).*?\3)/g,
       `var $1;require($2).then(ns=>$1=ns)`
     )
     .replace(
-      /\bimport (\w+?) from ((["']).*?\3)/g,
+      /\bimport ([a-zA-Z0-9_$]+?) from ((["']).*?\3)/g,
       `import {default as $1} from $2`
     )
     .replace(
@@ -154,7 +154,7 @@ hook.hook(".js", (src, name) => {
   const late_exports = []
   src = src
     .replace(
-      /\bexport (var|let|const) ((?:\w+(?:=[^,\n;]+)?,\s*)*\w+(?:=[^,\n;]+)?)/g,
+      /\bexport (var|let|const) ((?:[a-zA-Z0-9_$]+(?:=[^,\n;]+)?,\s*)*[a-zA-Z0-9_$]+(?:=[^,\n;]+)?)/g,
       (all, $1, $2) => {
         exports_seen++
         late_exports.push(

--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ class IdentifierList {
   }
 }
 
-hook.hook('.js', (src, name) => {
+hook.hook(".js", (src, name) => {
   /* How this works:
    *
    * At a simple level, `import {Foo} from "./foo"` is the same as
@@ -145,30 +145,40 @@ hook.hook('.js', (src, name) => {
 
   src = src.replace(/\bexport default +/g, () => {
     exports_seen++
-    return 'module.exports.ns.default='
+    return "module.exports.ns.default="
   })
 
-  var late_exports = [];
-  src = src.replace(/\bexport (var|let|const) ((?:\w+(?:=[^,\n;]+)?,\s*)*\w+(?:=[^,\n;]+)?)/g, (all, $1, $2) => {
-    exports_seen++
-    late_exports.push(
-      ...$2.split(/,/).map(n => n.replace(/=.*/, "").trim())
-    );
-    return `${$1} ${$2}`;
-  });
-  src = src.replace(
-    /\bexport (function|class) ([a-zA-Z0-9_$]*)/g,
-    () => {
-      exports_seen++
-      return 'module.exports.ns.$2=$1 $2'
-    }
-  );
-  src = src.replace(/\bexport {(.*?)}/g, (all, $1) => {
-    exports_seen++
-    return new IdentifierList($1).exportAll()
-  })
+  /**
+   * @type {string[]}
+   */
+  const late_exports = []
+  src = src
+    .replace(
+      /\bexport (var|let|const) ((?:\w+(?:=[^,\n;]+)?,\s*)*\w+(?:=[^,\n;]+)?)/g,
+      (all, $1, $2) => {
+        exports_seen++
+        late_exports.push(
+          ...$2.split(/,/).map(n => n.replace(/=.*/, "").trim())
+        )
+        return `${$1} ${$2}`
+      }
+    )
+    .replace(
+      /\bexport (function|class) ([a-zA-Z0-9_$]*)/g,
+      () => {
+        exports_seen++
+        return "module.exports.ns.$2=$1 $2"
+      }
+    )
+    .replace(
+      /\bexport {(.*?)}/g,
+      (all, $1) => {
+        exports_seen++
+        return new IdentifierList($1).exportAll()
+      }
+    )
   if(exports_seen) {
-    return `module.exports=require('eximport-bridge').bridge;${src}\nmodule.exports.commit({${late_exports.map(n => `"${n}":${n}`).join(",")}});`
+    return `module.exports=require("eximport-bridge").bridge;${src}\nmodule.exports.commit({${late_exports.map(n => `"${n}":${n}`).join(",")}});`
   } else {
     return src
   }

--- a/index.js
+++ b/index.js
@@ -72,6 +72,15 @@ hook.hook('.js', (src, name) => {
     ).join(";") +
     `})`
   }
+
+  src = src.replace(
+    /\bimport (\w+?), {([^{]*?)} from (["'])(.*?)\3/g,
+    'import $1 from "$4"; import {$2} from "$4"'
+  );
+  src = src.replace(
+    /\bimport (\w+?), [*] as (\w+?) from (["'])(.*?)\3/g,
+    'import $1 from "$4"; import * as $2 from "$4"'
+  );
   src = src.replace(
     /\bimport [*] as (\w+?) from (["'])(.*?)\2/g,
     'var $1;require("$3").importer(ns=>$1=ns)'

--- a/index.js
+++ b/index.js
@@ -1,14 +1,14 @@
 var hook = require('node-hook');
 
 hook.hook('.js', (src, name) => {
-  src = src.replace(/import ([^{]*?) from '(.*?)'/g, 'const $1 = require("$2")');
+  src = src.replace(/import ([^{]*?) from (["'])(.*?)\2/g, 'const $1 = require("$3")');
   src = src.replace(/export default ([^ ]*)/g, 'module.exports = $1');
   src = src.replace(/export (var|let|const) ([a-zA-Z0-9_$]*)/g, '$1 $2 = module.exports.$2');
   src = src.replace(/export function ([a-zA-Z0-9_$]*)/g, 'var $1 = module.exports.$1 = function');
   src = src.replace(/export class ([a-zA-Z0-9_$]*)/g, 'var $1 = module.exports.$1 = class');
-  src = src.replace(/import {(.*?)} from '(.*?)'/g, (all, $1, $2) => {
+  src = src.replace(/import {(.*?)} from (["'])(.*?)\2/g, (all, $1, $2, $3) => {
     return $1.split(",")
-      .map(part => 'var ' + part + '= require("' + $2 + '").' + part.trim() + ';')
+      .map(part => 'var ' + part + '= require("' + $3 + '").' + part.trim() + ';')
       .join('');
   });
   return src;

--- a/index.js
+++ b/index.js
@@ -2,18 +2,18 @@ var hook = require('node-hook');
 
 hook.hook('.js', (src, name) => {
   var seen_names = {};
-  src = src.replace(/import ([^{]*?) from (["'])(.*?)\2/g, (all, $1, $2, $3) => {
+  src = src.replace(/\bimport ([^{]*?) from (["'])(.*?)\2/g, (all, $1, $2, $3) => {
     seen_names[$1.trim()] = $3;
     return `imported["${$3}"] = require("${$3}")`;
   });
-  src = src.replace(/export default ([^ ]*)/g, 'module.exports = $1');
-  src = src.replace(/export (var|let|const) ([a-zA-Z0-9_$]*)/g, '$1 $2 = module.exports.$2');
-  src = src.replace(/export function ([a-zA-Z0-9_$]*)/g, 'var $1 = module.exports.$1 = function');
-  src = src.replace(/export class ([a-zA-Z0-9_$]*)/g, 'var $1 = module.exports.$1 = class');
-  src = src.replace(/export {(.*?)}/g, (all, $1) => {
+  src = src.replace(/\bexport default ([^ ]*)/g, 'module.exports = $1');
+  src = src.replace(/\bexport (var|let|const) ([a-zA-Z0-9_$]*)/g, '$1 $2 = module.exports.$2');
+  src = src.replace(/\bexport function ([a-zA-Z0-9_$]*)/g, 'var $1 = module.exports.$1 = function');
+  src = src.replace(/\bexport class ([a-zA-Z0-9_$]*)/g, 'var $1 = module.exports.$1 = class');
+  src = src.replace(/\bexport {(.*?)}/g, (all, $1) => {
     return $1.split(/,/).map(name => `module.exports.${name.trim()} = ${name.trim()}`).join(";");
   });
-  src = src.replace(/import {(.*?)} from (["'])(.*?)\2/g, (all, $1, $2, $3) => {
+  src = src.replace(/\bimport {(.*?)} from (["'])(.*?)\2/g, (all, $1, $2, $3) => {
     $1.split(",").forEach(name => {
         seen_names[name.trim()] = $3;
     });

--- a/index.js
+++ b/index.js
@@ -93,6 +93,10 @@ hook.hook('.js', (src, name) => {
     /\bimport {([^{]*?)} from (["'])(.*?)\2/g,
     (all, $1, $2, $3) => importAll($3, identifierList($1))
   );
+  src = src.replace(
+    /\bimport (["'])(.*?)\1/g,
+    'require("$2")'
+  );
 
   src = src.replace(/\bexport default +/g, 'module.exports.ns.default = ');
   src = src.replace(/\bexport (var|let|const) ([a-zA-Z0-9_$]*)/g, (all, $1, $2) => {

--- a/index.js
+++ b/index.js
@@ -147,13 +147,7 @@ hook.hook('.js', (src, name) => {
     ).join(";")
   })
   if(exports_seen) {
-    return "var importers=[];" +
-      "module.exports.ns={};" +
-      "module.exports.importer=f=>importers.push(f);" +
-      src + "\n" +
-      late_exports.map(n => `module.exports.ns.${n}=${n};`).join("") +
-      "module.exports.importer=f=>f(module.exports.ns);" +
-      "importers.forEach(f=>f(module.exports.ns));";
+    return `module.exports=require('eximport-bridge').bridge;${src}\nmodule.exports.commit({${late_exports.map(n => `"${n}":${n}`).join(",")}});`
   } else {
     return src
   }

--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ hook.hook('.js', (src, name) => {
    */
   function importAll(file, dest_to_src) {
     return `var ${Object.keys(dest_to_src).join(",")};` +
-    `require("${file}").importer(ns=>{` +
+    `require("${file}").then(ns=>{` +
     Object.keys(dest_to_src).map(dest =>
       `${dest}=ns.${dest_to_src[dest]}`
     ).join(";") +
@@ -83,7 +83,7 @@ hook.hook('.js', (src, name) => {
   );
   src = src.replace(
     /\bimport [*] as (\w+?) from (["'])(.*?)\2/g,
-    'var $1;require("$3").importer(ns=>$1=ns)'
+    'var $1;require("$3").then(ns=>$1=ns)'
   );
   src = src.replace(
     /\bimport (\w+?) from (["'])(.*?)\2/g,
@@ -103,7 +103,7 @@ hook.hook('.js', (src, name) => {
     /\bexport [*] from (["'])(.*?)\1/g,
     (a, $1, $2) => {
       exports_seen++
-      return `require("${$2}").importer(ns=>Object.assign(module.exports.ns,ns,{default:module.exports.ns.default}))`
+      return `require("${$2}").then(ns=>Object.assign(module.exports.ns,ns,{default:module.exports.ns.default}))`
     },
   )
   src = src.replace(
@@ -111,7 +111,7 @@ hook.hook('.js', (src, name) => {
     (all, $1, $2, $3) => {
       exports_seen++
       const names = identifierList($1)
-      return `require("${$3}").importer(ns=>{` +
+      return `require("${$3}").then(ns=>{` +
         Object.keys(names).map(
           name => `module.exports.ns.${name}=ns.${names[name]}`
         ).join(";") +

--- a/index.js
+++ b/index.js
@@ -1,176 +1,114 @@
 const hook = require("node-hook")
 
-class IdentifierList {
-  /**
-   * Converts a name expression string into a map from destination names to source names.
-   *
-   * @param {string} identifier_list eg. "foo as bar, baz"
-   */
-  constructor(identifier_list) {
-    /**
-     * @type {{[local_name: string]: string}}
-     */
-    this.destToSrc = {}
-    for(const identifier of identifier_list.split(/,/)) {
-      let md
-      if(md = identifier.match(/([a-zA-Z0-9_$]+) as ([a-zA-Z0-9_$]+)/)) {
-        this.add(md[2], md[1])
-      } else {
-        this.add(identifier.trim(), identifier.trim())
-      }
-    }
-  }
-  /**
-   *
-   * @param {string} local_name
-   * @param {string} remote_name
-   * @throws
-   */
-  add(local_name, remote_name) {
-    if(!local_name.match(/^[a-zA-Z0-9_$]+$/)) {
-      throw new Error(`Invalid import name: ${local_name}`)
-    }
-    if(!remote_name.match(/^[a-zA-Z0-9_$]+$/)) {
-      throw new Error(`Invalid export name: ${remote_name}`)
-    }
-    this.destToSrc[local_name] = remote_name
-  }
-  exportAll() {
-    return Object.keys(this.destToSrc).map(
-      k => `module.exports.ns.${k}=${this.destToSrc[k]}`
-    ).join(";")
-  }
-  /**
-   * Returns injectable source to export the given destination-to-source
-   * map of names from the given file.
-   *
-   * @param {string} file_quoted
-   * @return {string}
-   */
-  exportAllFrom(file_quoted) {
-    const local_names = Object.keys(this.destToSrc)
-    return `module.exports.exportFrom(require(${file_quoted}),{${local_names.map(name => `${name}:"${this.destToSrc[name]}"`).join(",")}})`
-  }
-  /**
-   * Returns injectable source to import the given destination-to-source
-   * map of names from the given file.
-   *
-   * @param {string} file_quoted
-   * @return {string}
-   */
-  importAllFrom(file_quoted) {
-    const local_names = Object.keys(this.destToSrc)
-    return `var ${local_names.join(",")};require(${file_quoted}).then(ns=>{${local_names.map(dest => `${dest}=ns.${this.destToSrc[dest]}`).join(";")}})`
-  }
-}
+const IdentifierList = require("./lib/identifier-list")
 
 hook.hook(".js", (src, name) => {
-  /* How this works:
-   *
-   * At a simple level, `import {Foo} from "./foo"` is the same as
-   * `var Foo = require("./foo").Foo`. Unfortunately it's not quite that simple because
-   * "export" hoists (its names exist before the code delaring them is executed), which is
-   * very valuable when you have circular references but needs to be emulated here.
-   *
-   * Instead, the code `import {Foo} from "./foo"` becomes roughly:
-   *
-   *     var Foo = require("./foo").Foo; // Original line position
-   *     // Other code before the main script run starts...
-   *     Foo = require("./foo").Foo;
-   *
-   * This means that we can fill in the namespace entry early and then before anything really
-   * uses it we can insert the final value. Specifically, we can do that as soon as the
-   * exporting module body execution finishes.
-   *
-   * The initial "var" line has to appear at its original (presumably top) level; by doing so
-   * it inserts an entry directly into the correct namespace. It won't work inside a function.
-   * Once the name exists though, and plain assignment in any scope which inherits the
-   * original namespace is fine, so the second half is done via a callback function. It
-   * doesn't make sense to do a second assingment once the module's evaluation is complete, so
-   * at that point the callback handler is dummied out and any pending callbacks executed.
-   *
-   * On the exporting side, `export Foo` becomes:
-   *
-   *     module.exports.Foo = null;
-   *     // Other module code...
-   *     module.exports.Foo = Foo; // Original line position
-   *     // Other module code...
-   *
-   * This ensures that the names all exist before any other code's import returns, and sets
-   * the correct value once it's known. It's necessary to do this in two stages because only
-   * one type of value has both its declaration and value hoisted: explicitly named functions.
-   */
+    /* How this works:
+    *
+    * At a simple level, `import {Foo} from "./foo"` is the same as
+    * `var Foo = require("./foo").Foo`. Unfortunately it's not quite that simple because
+    * "export" hoists (its names exist before the code delaring them is executed), which is
+    * very valuable when you have circular references but needs to be emulated here.
+    *
+    * Instead, the code `import {Foo} from "./foo"` becomes roughly:
+    *
+    *     var Foo = require("./foo").Foo; // Original line position
+    *     // Other code before the main script run starts...
+    *     Foo = require("./foo").Foo;
+    *
+    * This means that we can fill in the namespace entry early and then before anything really
+    * uses it we can insert the final value. Specifically, we can do that as soon as the
+    * exporting module body execution finishes.
+    *
+    * The initial "var" line has to appear at its original (presumably top) level; by doing so
+    * it inserts an entry directly into the correct namespace. It won't work inside a function.
+    * Once the name exists though, and plain assignment in any scope which inherits the
+    * original namespace is fine, so the second half is done via a callback function. It
+    * doesn't make sense to do a second assingment once the module's evaluation is complete, so
+    * at that point the callback handler is dummied out and any pending callbacks executed.
+    *
+    * On the exporting side, `export Foo` becomes:
+    *
+    *     module.exports.Foo = null;
+    *     // Other module code...
+    *     module.exports.Foo = Foo; // Original line position
+    *     // Other module code...
+    *
+    * This ensures that the names all exist before any other code's import returns, and sets
+    * the correct value once it's known. It's necessary to do this in two stages because only
+    * one type of value has both its declaration and value hoisted: explicitly named functions.
+    */
 
-  src = src
-    .replace(
-      /\bimport ([a-zA-Z0-9_$]+?), {([^{]*?)} from ((["'`]).*?\4)/g,
-      `import $1 from $3;import {$2} from $3`
-    )
-    .replace(
-      /\bimport ([a-zA-Z0-9_$]+?), [*] as ([a-zA-Z0-9_$]+?) from ((["'`]).*?\4)/g,
-      `import $1 from $3;import * as $2 from $3`
-    )
-    .replace(
-      /\bimport [*] as ([a-zA-Z0-9_$]+?) from ((["'`]).*?\3)/g,
-      `var $1;require($2).then(ns=>$1=ns)`
-    )
-    .replace(
-      /\bimport ([a-zA-Z0-9_$]+?) from ((["'`]).*?\3)/g,
-      `import {default as $1} from $2`
-    )
-    .replace(
-      /\bimport {([^{]*?)} from ((["'`]).*?\3)/g,
-      (all, $1, $2, $3) => new IdentifierList($1).importAllFrom($2)
-    )
-    .replace(
-      /\bimport ((["'`]).*?\2)/g,
-      `require($1)`
-    )
-  let exports_seen = 0
-  const exporting = (v) => {
-    exports_seen++
-    return v
-  }
-
-  src = src
-    .replace(
-      /\bexport [*] from ((["'`]).*?\2)/g,
-      (a, $1, $2) => exporting(`module.exports.exportFrom(require(${$1}))`)
-    )
-    .replace(
-      /\bexport [{]([^{]*?)[}] from ((["'`]).*?\3)/g,
-      (all, $1, $2, $3) => exporting(new IdentifierList($1).exportAllFrom($2))
-    )
-    .replace(
-      /\bexport default +/g,
-      () => exporting("module.exports.ns.default=")
-    )
-
-  /**
-   * @type {string[]}
-   */
-  const late_exports = []
-  src = src
-    .replace(
-      /\bexport (var|let|const) ((?:[a-zA-Z0-9_$]+(?:=[^,\n;]+)?,\s*)*[a-zA-Z0-9_$]+(?:=[^,\n;]+)?)/g,
-      (all, $1, $2) => {
-        late_exports.push(
-          ...$2.split(/,/).map(n => n.replace(/=.*/, "").trim())
+    src = src
+        .replace(
+            /\bimport ([a-zA-Z0-9_$]+?), {([^{]*?)} from ((["'`]).*?\4)/g,
+            `import $1 from $3;import {$2} from $3`
         )
-        return exporting(`${$1} ${$2}`)
-      }
-    )
-    .replace(
-      /\bexport (function|class) ([a-zA-Z0-9_$]*)/g,
-      (a, $1, $2) => exporting(`module.exports.ns.${$2}=${$1} ${$2}`)
-    )
-    .replace(
-      /\bexport {(.*?)}/g,
-      (all, $1) => exporting(new IdentifierList($1).exportAll())
-    )
-  if(exports_seen) {
-    return `module.exports=require("eximport-bridge").bridge;${src}\nmodule.exports.commit({${late_exports.map(n => `"${n}":${n}`).join(",")}});`
-  } else {
-    return src
-  }
+        .replace(
+            /\bimport ([a-zA-Z0-9_$]+?), [*] as ([a-zA-Z0-9_$]+?) from ((["'`]).*?\4)/g,
+            `import $1 from $3;import * as $2 from $3`
+        )
+        .replace(
+            /\bimport [*] as ([a-zA-Z0-9_$]+?) from ((["'`]).*?\3)/g,
+            `var $1;require($2).then(ns=>$1=ns)`
+        )
+        .replace(
+            /\bimport ([a-zA-Z0-9_$]+?) from ((["'`]).*?\3)/g,
+            `import {default as $1} from $2`
+        )
+        .replace(
+            /\bimport {([^{]*?)} from ((["'`]).*?\3)/g,
+            (all, $1, $2, $3) => new IdentifierList($1).importAllFrom($2)
+        )
+        .replace(
+            /\bimport ((["'`]).*?\2)/g,
+            `require($1)`
+        )
+    let exports_seen = 0
+    const exporting = (v) => {
+        exports_seen++
+        return v
+    }
+
+    src = src
+        .replace(
+            /\bexport [*] from ((["'`]).*?\2)/g,
+            (a, $1, $2) => exporting(`module.exports.exportFrom(require(${$1}))`)
+        )
+        .replace(
+            /\bexport [{]([^{]*?)[}] from ((["'`]).*?\3)/g,
+            (all, $1, $2, $3) => exporting(new IdentifierList($1).exportAllFrom($2))
+        )
+        .replace(
+            /\bexport default +/g,
+            () => exporting("module.exports.ns.default=")
+        )
+
+    /**
+     * @type {string[]}
+     */
+    const late_exports = []
+    src = src
+        .replace(
+            /\bexport (var|let|const) ((?:[a-zA-Z0-9_$]+(?:=[^,\n;]+)?,\s*)*[a-zA-Z0-9_$]+(?:=[^,\n;]+)?)/g,
+            (all, $1, $2) => {
+                late_exports.push(
+                    ...$2.split(/,/).map(n => n.replace(/=.*/, "").trim())
+                )
+                return exporting(`${$1} ${$2}`)
+            }
+        )
+        .replace(
+            /\bexport (function|class) ([a-zA-Z0-9_$]*)/g,
+            (a, $1, $2) => exporting(`module.exports.ns.${$2}=${$1} ${$2}`)
+        )
+        .replace(
+            /\bexport {(.*?)}/g,
+            (all, $1) => exporting(new IdentifierList($1).exportAll())
+        )
+    if(exports_seen) {
+        return `module.exports=require("eximport-bridge").bridge;${src}\nmodule.exports.commit({${late_exports.map(n => `"${n}":${n}`).join(",")}});`
+    } else {
+        return src
+    }
 })

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ hook.hook('.js', (src, name) => {
     seen_names[$1.trim()] = $3;
     return `imported["${$3}"] = require("${$3}")`;
   });
-  src = src.replace(/\bexport default ([^ ]*)/g, 'module.exports = $1');
+  src = src.replace(/\bexport default +/g, 'module.exports = ');
   src = src.replace(/\bexport (var|let|const) ([a-zA-Z0-9_$]*)/g, '$1 $2 = module.exports.$2');
   src = src.replace(/\bexport function ([a-zA-Z0-9_$]*)/g, 'var $1 = module.exports.$1 = function');
   src = src.replace(/\bexport class ([a-zA-Z0-9_$]*)/g, 'var $1 = module.exports.$1 = class');

--- a/index.js
+++ b/index.js
@@ -118,7 +118,7 @@ hook.hook(".js", (src, name) => {
             (all, $1) => exporting(new IdentifierList($1).exportAll())
         )
     if(exports_seen) {
-        return `module.exports=require("eximport-bridge").bridge;${src}\nmodule.exports.commit({${late_exports.map(n => `"${n}":${n}`).join(",")}});`
+        return `module.exports=require("eximport-bridge").bridge;${src}\nmodule.exports.commit({${late_exports.map(n => `${n}:${n}`).join(",")}});`
     } else {
         return src
     }

--- a/index.js
+++ b/index.js
@@ -8,8 +8,10 @@ hook.hook('.js', (src, name) => {
   });
   src = src.replace(/\bexport default +/g, 'module.exports.ns = ');
   src = src.replace(/\bexport (var|let|const) ([a-zA-Z0-9_$]*)/g, '$1 $2 = module.exports.ns.$2');
-  src = src.replace(/\bexport function ([a-zA-Z0-9_$]*)/g, 'var $1 = module.exports.ns.$1 = function');
-  src = src.replace(/\bexport class ([a-zA-Z0-9_$]*)/g, 'var $1 = module.exports.ns.$1 = class');
+  src = src.replace(
+    /\bexport (function|class) ([a-zA-Z0-9_$]*)/g,
+    'var $2 = module.exports.ns.$2 = $1'
+);
   src = src.replace(/\bexport {(.*?)}/g, (all, $1) => {
     var names = $1.split(/,/);
     return names.map(

--- a/index.js
+++ b/index.js
@@ -6,6 +6,19 @@ hook.hook('.js', (src, name) => {
     seen_names[$1.trim()] = $3;
     return `imported["${$3}"] = require("${$3}").ns`;
   });
+  src = src.replace(/\bimport {(.*?)} from (["'])(.*?)\2/g, (all, $1, $2, $3) => {
+    $1.split(",").forEach(name => {
+        seen_names[name.trim()] = $3;
+    });
+    return `imported["${$3}"] = require("${$3}").ns`;
+  });
+  if(Object.keys(seen_names).length) {
+      // Ultimately we want AST parsing but this will work in most cases.
+      Object.keys(seen_names).forEach(name => {
+        src = src.replace(new RegExp(`\\b${name}\\b`, "g"), `imported["${seen_names[name]}"].${name}`)
+      });
+      src = "var imported = {};" + src;
+  }
   src = src.replace(/\bexport default +/g, 'module.exports.ns = ');
   src = src.replace(/\bexport (var|let|const) ([a-zA-Z0-9_$]*)/g, '$1 $2 = module.exports.ns.$2');
   src = src.replace(
@@ -17,15 +30,5 @@ hook.hook('.js', (src, name) => {
     return names.map(
         name => `module.exports.ns.${name.trim()} = ${names[name.trim()]}`
     ).join(";");
-  src = src.replace(/\bimport {(.*?)} from (["'])(.*?)\2/g, (all, $1, $2, $3) => {
-    $1.split(",").forEach(name => {
-        seen_names[name.trim()] = $3;
-    });
-    return `imported["${$3}"] = require("${$3}").ns`;
-  });
-  // Ultimately we want AST parsing but this will work in most cases.
-  Object.keys(seen_names).forEach(name => {
-    src = src.replace(new RegExp(`\\b${name}\\b`, "g"), `imported["${seen_names[name]}"].${name}`)
-  });
-  return "var imported = {};" + src;
+  return src;
 });

--- a/index.js
+++ b/index.js
@@ -73,7 +73,11 @@ hook.hook('.js', (src, name) => {
     `})`
   }
   src = src.replace(
-    /\bimport ([^{]*?) from (["'])(.*?)\2/g,
+    /\bimport [*] as (\w+?) from (["'])(.*?)\2/g,
+    'var $1;require("$3").importer(ns=>$1=ns)'
+  );
+  src = src.replace(
+    /\bimport (\w+?) from (["'])(.*?)\2/g,
     (all, $1, $2, $3) => importAll($3, {[$1]: "default"})
   );
   src = src.replace(

--- a/index.js
+++ b/index.js
@@ -1,34 +1,94 @@
 var hook = require('node-hook');
 
 hook.hook('.js', (src, name) => {
-  var seen_names = {};
-  src = src.replace(/\bimport ([^{]*?) from (["'])(.*?)\2/g, (all, $1, $2, $3) => {
-    seen_names[$1.trim()] = $3;
-    return `imported["${$3}"] = require("${$3}").ns`;
-  });
-  src = src.replace(/\bimport {(.*?)} from (["'])(.*?)\2/g, (all, $1, $2, $3) => {
-    $1.split(",").forEach(name => {
-        seen_names[name.trim()] = $3;
-    });
-    return `imported["${$3}"] = require("${$3}").ns`;
-  });
-  if(Object.keys(seen_names).length) {
-      // Ultimately we want AST parsing but this will work in most cases.
-      Object.keys(seen_names).forEach(name => {
-        src = src.replace(new RegExp(`\\b${name}\\b`, "g"), `imported["${seen_names[name]}"].${name}`)
-      });
-      src = "var imported = {};" + src;
+  /* How this works:
+   *
+   * At a simple level, `import {Foo} from "./foo"` is the same as
+   * `var Foo = require("./foo").Foo`. Unfortunately it's not quite that simple because
+   * "export" hoists (its names exist before the code delaring them is executed), which is
+   * very valuable when you have circular references but needs to be emulated here.
+   *
+   * Instead, the code `import {Foo} from "./foo"` becomes roughly:
+   *
+   *     var Foo = require("./foo").Foo; // Original line position
+   *     // Other code before the main script run starts...
+   *     Foo = require("./foo").Foo;
+   *
+   * This means that we can fill in the namespace entry early and then before anything really
+   * uses it we can insert the final value. Specifically, we can do that as soon as the
+   * exporting module body execution finishes.
+   *
+   * The initial "var" line has to appear at its original (presumably top) level; by doing so
+   * it inserts an entry directly into the correct namespace. It won't work inside a function.
+   * Once the name exists though, and plain assignment in any scope which inherits the
+   * original namespace is fine, so the second half is done via a callback function. It
+   * doesn't make sense to do a second assingment once the module's evaluation is complete, so
+   * at that point the callback handler is dummied out and any pending callbacks executed.
+   *
+   * On the exporting side, `export Foo` becomes:
+   *
+   *     module.exports.Foo = null;
+   *     // Other module code...
+   *     module.exports.Foo = Foo; // Original line position
+   *     // Other module code...
+   *
+   * This ensures that the names all exist before any other code's import returns, and sets
+   * the correct value once it's known. It's necessary to do this in two stages because only
+   * one type of value has both its declaration and value hoisted: explicitly named functions.
+   */
+
+  /**
+   * Returns injectable source to import the given destination-to-source
+   * map of names from the given file.
+   *
+   * @param {string} file
+   * @param {object} dest_to_src
+   * @return {string}
+   */
+  function importAll(file, dest_to_src) {
+    return `var ${Object.keys(dest_to_src).join(",")};` +
+    `require("${file}").importer(ns=>{` +
+    Object.keys(dest_to_src).map(dest =>
+      `${dest}=ns.${dest_to_src[dest]}`
+    ).join(";") +
+    `})`
   }
-  src = src.replace(/\bexport default +/g, 'module.exports.ns = ');
-  src = src.replace(/\bexport (var|let|const) ([a-zA-Z0-9_$]*)/g, '$1 $2 = module.exports.ns.$2');
+  src = src.replace(
+    /\bimport ([^{]*?) from (["'])(.*?)\2/g,
+    (all, $1, $2, $3) => importAll($3, {[$1]: "default"})
+  );
+  src = src.replace(
+    /\bimport {([^{]*?)} from (["'])(.*?)\2/g,
+    (all, $1, $2, $3) => {
+      var names = {};
+      $1.split(/,/).forEach(name => names[name.trim()] = null);
+      return importAll($3, names);
+    }
+  );
+
+  src = src.replace(/\bexport default +/g, 'module.exports.ns.default = ');
+  src = src.replace(/\bexport (var|let|const) ([a-zA-Z0-9_$]*)/g, (all, $1, $2) => {
+    return `module.exports.ns.${$2} = ${$1} ${$2}`;
+  });
   src = src.replace(
     /\bexport (function|class) ([a-zA-Z0-9_$]*)/g,
-    'var $2 = module.exports.ns.$2 = $1'
-);
+    'module.exports.ns.$2 = $1 $2'
+  );
+
   src = src.replace(/\bexport {(.*?)}/g, (all, $1) => {
-    var names = $1.split(/,/);
-    return names.map(
-        name => `module.exports.ns.${name.trim()} = ${names[name.trim()]}`
+    var names = identifierList($1);
+    return Object.keys(names).map(
+        k => `module.exports.ns.${k} = ${names[k]}`
     ).join(";");
-  return src;
+  });
+  if(src.match(/\bmodule.exports\b/)) {
+    return "var importers = []; " +
+      "module.exports.ns = {}; " +
+      "module.exports.importer = f => importers.push(f);" +
+      src + "\n" +
+      "module.exports.importer = f => f(module.exports.ns);" +
+      "importers.forEach(f => f(module.exports.ns));";
+  } else {
+    return src;
+  }
 });

--- a/index.js
+++ b/index.js
@@ -88,15 +88,26 @@ hook.hook(".js", (src, name) => {
      * @type {string[]}
      */
     const late_exports = []
+    /**
+     *
+     * @param {string} type
+     * @param {string} names_values
+     */
+    function add_late_export(type, names_values) {
+        for(const nv of names_values.split(/,/)) {
+            const n = nv.replace(/=.*/, "").trim()
+            if(n.match(/^[a-zA-Z0-9_$]+$/)) {
+                late_exports.push(n)
+            } else {
+                throw new Error(`Invalid export name: ${n}`)
+            }
+        }
+        return exporting(`${type} ${names_values}`)
+    }
     src = src
         .replace(
             /\bexport (var|let|const) ((?:[a-zA-Z0-9_$]+(?:=[^,\n;]+)?,\s*)*[a-zA-Z0-9_$]+(?:=[^,\n;]+)?)/g,
-            (all, $1, $2) => {
-                late_exports.push(
-                    ...$2.split(/,/).map(n => n.replace(/=.*/, "").trim())
-                )
-                return exporting(`${$1} ${$2}`)
-            }
+            (all, $1, $2) => add_late_export($1, $2)
         )
         .replace(
             /\bexport (function|class) ([a-zA-Z0-9_$]*)/g,

--- a/index.js
+++ b/index.js
@@ -6,6 +6,9 @@ hook.hook('.js', (src, name) => {
   src = src.replace(/export (var|let|const) ([a-zA-Z0-9_$]*)/g, '$1 $2 = module.exports.$2');
   src = src.replace(/export function ([a-zA-Z0-9_$]*)/g, 'var $1 = module.exports.$1 = function');
   src = src.replace(/export class ([a-zA-Z0-9_$]*)/g, 'var $1 = module.exports.$1 = class');
+  src = src.replace(/export {(.*?)}/g, (all, $1) => {
+    return $1.split(/,/).map(name => `module.exports.${name.trim()} = ${name.trim()}`).join(";");
+  });
   src = src.replace(/import {(.*?)} from (["'])(.*?)\2/g, (all, $1, $2, $3) => {
     return $1.split(",")
       .map(part => 'var ' + part + '= require("' + $3 + '").' + part.trim() + ';')

--- a/index.js
+++ b/index.js
@@ -118,7 +118,7 @@ hook.hook(".js", (src, name) => {
             (all, $1) => exporting(new IdentifierList($1).exportAll())
         )
     if(exports_seen) {
-        return `eximportBridge=require("eximport-bridge").bridge;module.exports=eximportBridge.ns;${src}\neximportBridge.commit({${late_exports.map(n => `${n}:${n}`).join(",")}});`
+        return `let eximportBridge=require("eximport-bridge").bridge;module.exports=eximportBridge.ns;${src}\neximportBridge.commit({${late_exports.map(n => `${n}:${n}`).join(",")}});`
     } else {
         return src
     }

--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ hook.hook(".js", (src, name) => {
         )
         .replace(
             /\bexport (function|class) ([a-zA-Z0-9_$]*)/g,
-            (a, $1, $2) => exporting(`eximportBridge.ns.${$2}=${$1} ${$2}`)
+            (a, $1, $2) => exporting(`const ${$2}=eximportBridge.ns.${$2}=${$1} ${$2}`)
         )
         .replace(
             /\bexport {(.*?)}/g,

--- a/index.js
+++ b/index.js
@@ -38,6 +38,25 @@ hook.hook('.js', (src, name) => {
    */
 
   /**
+   * Converts a name expression string into a map from destination names to source names.
+   *
+   * @param {string} identifier_list eg. "foo as bar, baz"
+   * @return {object} eg. {bar:"foo",baz:"baz"}
+   */
+  function identifierList(identifier_list) {
+    var dest_to_src = {};
+    identifier_list.split(/,/).forEach(identifier => {
+      var md;
+      if(md = identifier.match(/(\w+) as (\w+)/)) {
+        dest_to_src[md[2]] = md[1];
+      } else {
+        dest_to_src[identifier.trim()] = identifier.trim();;
+      }
+    });
+    return dest_to_src;
+  }
+
+  /**
    * Returns injectable source to import the given destination-to-source
    * map of names from the given file.
    *
@@ -59,11 +78,7 @@ hook.hook('.js', (src, name) => {
   );
   src = src.replace(
     /\bimport {([^{]*?)} from (["'])(.*?)\2/g,
-    (all, $1, $2, $3) => {
-      var names = {};
-      $1.split(/,/).forEach(name => names[name.trim()] = null);
-      return importAll($3, names);
-    }
+    (all, $1, $2, $3) => importAll($3, identifierList($1))
   );
 
   src = src.replace(/\bexport default +/g, 'module.exports.ns.default = ');

--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ hook.hook(".js", (src, name) => {
     src = src
         .replace(
             /\bexport [*] from ((["'`]).*?\2)/g,
-            (a, $1, $2) => exporting(`module.exports.exportFrom(require(${$1}))`)
+            (a, $1, $2) => exporting(`eximportBridge.exportFrom(require(${$1}))`)
         )
         .replace(
             /\bexport [{]([^{]*?)[}] from ((["'`]).*?\3)/g,
@@ -81,7 +81,7 @@ hook.hook(".js", (src, name) => {
         )
         .replace(
             /\bexport default +/g,
-            () => exporting("module.exports.ns.default=")
+            () => exporting("eximportBridge.ns.default=")
         )
 
     /**
@@ -111,14 +111,14 @@ hook.hook(".js", (src, name) => {
         )
         .replace(
             /\bexport (function|class) ([a-zA-Z0-9_$]*)/g,
-            (a, $1, $2) => exporting(`module.exports.ns.${$2}=${$1} ${$2}`)
+            (a, $1, $2) => exporting(`eximportBridge.ns.${$2}=${$1} ${$2}`)
         )
         .replace(
             /\bexport {(.*?)}/g,
             (all, $1) => exporting(new IdentifierList($1).exportAll())
         )
     if(exports_seen) {
-        return `module.exports=require("eximport-bridge").bridge;${src}\nmodule.exports.commit({${late_exports.map(n => `${n}:${n}`).join(",")}});`
+        return `eximportBridge=require("eximport-bridge").bridge;module.exports=eximportBridge;${src}\neximportBridge.commit({${late_exports.map(n => `${n}:${n}`).join(",")}});`
     } else {
         return src
     }

--- a/index.js
+++ b/index.js
@@ -87,7 +87,7 @@ hook.hook(".js", (src, name) => {
             (all, $1) => exporting(new IdentifierList($1).exportAll())
         )
     if(exports_seen) {
-        return `let eximportBridge=require("eximport-bridge").bridge;module.exports=eximportBridge.ns;${src}\neximportBridge.commit({${late_exports.map(n => `${n}:${n}`).join(",")}});`
+        return `const eximportBridge=require("eximport-bridge").bridge;module.exports=eximportBridge.ns;${src}\neximportBridge.commit({${late_exports.map(n => `${n}:${n}`).join(",")}});`
     } else {
         return src
     }

--- a/index.js
+++ b/index.js
@@ -70,6 +70,10 @@ hook.hook('.js', (src, name) => {
     if(invalid_names.length) {
       throw new Error(`Invalid import name(s): ${invalid_names}`)
     }
+    const invalid_source_names = Object.values(dest_to_src).filter(n => !n.match(/^\w+$/))
+    if(invalid_source_names.length) {
+      throw new Error(`Invalid source name(s): ${invalid_source_names}`)
+    }
     return `var ${local_names.join(",")};require("${file}").then(ns=>{${local_names.map(dest => `${dest}=ns.${dest_to_src[dest]}`).join(";")}})`
   }
 

--- a/index.js
+++ b/index.js
@@ -2,55 +2,40 @@ const hook = require("node-hook")
 
 const IdentifierList = require("./lib/identifier-list")
 
+const DEBUG = false
+
 hook.hook(".js", (src, name) => {
     /* This modifies the source of your included Javascript files so that any
      * import/export statements become require(). See the accompanying README
      * for details.
      */
 
-    src = src
-        .replace(
-            /\bimport ([a-zA-Z0-9_$]+?), {([^{]*?)} from ((["'`]).*?\4)/g,
-            `import $1 from $3;import {$2} from $3`
-        )
-        .replace(
-            /\bimport ([a-zA-Z0-9_$]+?), [*] as ([a-zA-Z0-9_$]+?) from ((["'`]).*?\4)/g,
-            `import $1 from $3;import * as $2 from $3`
-        )
-        .replace(
-            /\bimport [*] as ([a-zA-Z0-9_$]+?) from ((["'`]).*?\3)/g,
-            `var $1;require($2)._bridge.then(ns=>$1=ns)`
-        )
-        .replace(
-            /\bimport ([a-zA-Z0-9_$]+?) from ((["'`]).*?\3)/g,
-            `import {default as $1} from $2`
-        )
-        .replace(
-            /\bimport {([^{]*?)} from ((["'`]).*?\3)/g,
-            (all, $1, $2, $3) => new IdentifierList($1).importAllFrom($2)
-        )
-        .replace(
-            /\bimport ((["'`]).*?\2)/g,
-            `require($1)`
-        )
-    let exports_seen = 0
-    const exporting = (v) => {
-        exports_seen++
+    /** @type {(?string)[]} */
+    const exports_seen = []
+    /**
+     * @param {string} v
+     * @param {(string|null)[]} names
+     */
+    const exporting = (v, names) => {
+        exports_seen.push(...names)
         return v
     }
 
     src = src
         .replace(
             /\bexport [*] from ((["'`]).*?\2)/g,
-            (a, $1, $2) => exporting(`eximportBridge.exportFrom(require(${$1})._bridge)`)
+            (a, $1) => exporting(`eximportBridge.exportFrom(require(${$1})._bridge)`, [null])
         )
         .replace(
             /\bexport [{]([^{]*?)[}] from ((["'`]).*?\3)/g,
-            (all, $1, $2, $3) => exporting(new IdentifierList($1).exportAllFrom($2))
+            (a, $1, $2) => {
+                const il = new IdentifierList($1)
+                return exporting(il.exportAllFrom($2), Object.keys(il.destToSrc))
+            }
         )
         .replace(
             /\bexport default +/g,
-            () => exporting("eximportBridge.ns.default=")
+            () => exporting("yield eximportBridge.ns.default=", ["default"])
         )
 
     /**
@@ -63,31 +48,78 @@ hook.hook(".js", (src, name) => {
      * @param {string} names_values
      */
     function add_late_export(type, names_values) {
+        const new_late_exports = []
         for(const nv of names_values.split(/,/)) {
             const n = nv.replace(/=.*/, "").trim()
             if(n.match(/^[a-zA-Z0-9_$]+$/)) {
-                late_exports.push(n)
+                new_late_exports.push(n)
             } else {
                 throw new Error(`Invalid export name: ${n}`)
             }
         }
-        return exporting(`${type} ${names_values}`)
+        late_exports.push(...new_late_exports)
+        return exporting(`${type} ${names_values}`, new_late_exports)
     }
     src = src
         .replace(
             /\bexport (var|let|const) ((?:[a-zA-Z0-9_$]+(?:=[^,\n;]+)?,\s*)*[a-zA-Z0-9_$]+(?:=[^,\n;]+)?)/g,
-            (all, $1, $2) => add_late_export($1, $2)
+            (a, $1, $2) => add_late_export($1, $2)
         )
         .replace(
             /\bexport (function|class) ([a-zA-Z0-9_$]*)/g,
-            (a, $1, $2) => exporting(`const ${$2}=eximportBridge.ns.${$2}=${$1} ${$2}`)
+            (a, $1, $2) => exporting(`let ${$2};yield eximportBridge.ns.${$2}=${$2}=${$1}`, [$2])
         )
         .replace(
             /\bexport {(.*?)}/g,
-            (all, $1) => exporting(new IdentifierList($1).exportAll())
+            (a, $1) => {
+                const il = new IdentifierList($1)
+                return exporting(il.exportAll(), Object.keys(il.destToSrc))
+            }
         )
-    if(exports_seen) {
-        return `const eximportBridge=require("eximport-bridge").bridge;module.exports=eximportBridge.ns;${src}\neximportBridge.commit({${late_exports.map(n => `${n}:${n}`).join(",")}});`
+    let with_imports = 0
+    src = src
+        .replace(
+            /\bimport ([a-zA-Z0-9_$]+?), {([^{]*?)} from ((["'`]).*?\4)/g,
+            `import $1 from $3;import {$2} from $3`
+        )
+        .replace(
+            /\bimport ([a-zA-Z0-9_$]+?), [*] as ([a-zA-Z0-9_$]+?) from ((["'`]).*?\4)/g,
+            `import $1 from $3;import * as $2 from $3`
+        )
+        .replace(
+            /\bimport [*] as ([a-zA-Z0-9_$]+?) from ((["'`]).*?\3)/g,
+            exports_seen.length ? `var $1 = require($2)._bridge.ns;yield` : `var $1 = require($2)._bridge.ns`
+        )
+        .replace(
+            /\bimport ([a-zA-Z0-9_$]+?) from ((["'`]).*?\3)/g,
+            `import {default as $1} from $2`
+        )
+        .replace(
+            /\bimport {([^{]*?)} from ((["'`]).*?\3)/g,
+            (a, $1, $2) => {
+                with_imports++
+                return exports_seen.length ?
+                    new IdentifierList($1).importAllFrom($2) + ";yield" :
+                    new IdentifierList($1).importAllFrom($2)
+            }
+        )
+        .replace(
+            /\bimport ((["'`]).*?\2)/g,
+            exports_seen.length ?
+                `{const b = require($1)._bridge;yield;b.finish()}` :
+                `require($1)._bridge.finish()`
+        )
+    src += "}".repeat(with_imports)
+
+    if(exports_seen.length) {
+        const commit_src = late_exports.length ?
+            `${src};eximportBridge.commit({${late_exports.map(n => `${n}:${n}`).join(",")}})` :
+            src
+        const out = `const eximportBridge=require("eximport-bridge").prepareBridge(${JSON.stringify(exports_seen)});module.exports=eximportBridge.ns;eximportBridge.execute(function* () {${commit_src}})`
+        if(DEBUG) {
+            console.log(out.replace(/^/gm, "> "))
+        }
+        return out
     } else {
         return src
     }

--- a/lib/identifier-list.js
+++ b/lib/identifier-list.js
@@ -35,7 +35,7 @@ module.exports = class IdentifierList {
     }
     exportAll() {
         return Object.keys(this.destToSrc).map(
-            k => `module.exports.ns.${k}=${this.destToSrc[k]}`
+            k => `eximportBridge.ns.${k}=${this.destToSrc[k]}`
         ).join(";")
     }
     /**
@@ -47,7 +47,7 @@ module.exports = class IdentifierList {
      */
     exportAllFrom(file_quoted) {
         const local_names = Object.keys(this.destToSrc)
-        return `module.exports.exportFrom(require(${file_quoted}),{${local_names.map(name => `${name}:"${this.destToSrc[name]}"`).join(",")}})`
+        return `eximportBridge.exportFrom(require(${file_quoted}),{${local_names.map(name => `${name}:"${this.destToSrc[name]}"`).join(",")}})`
     }
     /**
      * Returns injectable source to import the given destination-to-source

--- a/lib/identifier-list.js
+++ b/lib/identifier-list.js
@@ -35,7 +35,7 @@ module.exports = class IdentifierList {
     }
     exportAll() {
         return Object.keys(this.destToSrc).map(
-            k => `eximportBridge.ns.${k}=${this.destToSrc[k]}`
+            k => `yield eximportBridge.ns.${k}=${this.destToSrc[k]}`
         ).join(";")
     }
     /**
@@ -47,7 +47,7 @@ module.exports = class IdentifierList {
      */
     exportAllFrom(file_quoted) {
         const local_names = Object.keys(this.destToSrc)
-        return `eximportBridge.exportFrom(require(${file_quoted})._bridge,{${local_names.map(name => `${name}:"${this.destToSrc[name]}"`).join(",")}})`
+        return `yield eximportBridge.exportFrom(require(${file_quoted})._bridge,{${local_names.map(name => `${name}:"${this.destToSrc[name]}"`).join(",")}})`
     }
     /**
      * Returns injectable source to import the given destination-to-source
@@ -57,7 +57,6 @@ module.exports = class IdentifierList {
      * @return {string}
      */
     importAllFrom(file_quoted) {
-        const local_names = Object.keys(this.destToSrc)
-        return `var ${local_names.join(",")};require(${file_quoted})._bridge.then(ns=>{${local_names.map(dest => `${dest}=ns.${this.destToSrc[dest]}`).join(";")}})`
+        return `with(require(${file_quoted})._bridge.named(${JSON.stringify(this.destToSrc)})){`
     }
 }

--- a/lib/identifier-list.js
+++ b/lib/identifier-list.js
@@ -1,0 +1,63 @@
+module.exports = class IdentifierList {
+    /**
+     * Converts a name expression string into a map from destination names to source names.
+     *
+     * @param {string} identifier_list eg. "foo as bar, baz"
+     */
+    constructor(identifier_list) {
+        /**
+         * @type {{[local_name: string]: string}}
+         */
+        this.destToSrc = {}
+        for(const identifier of identifier_list.split(/,/)) {
+            let md
+            if(md = identifier.match(/([a-zA-Z0-9_$]+) as ([a-zA-Z0-9_$]+)/)) {
+                this.add(md[2], md[1])
+            } else {
+                this.add(identifier.trim(), identifier.trim())
+            }
+        }
+    }
+    /**
+     *
+     * @param {string} local_name
+     * @param {string} remote_name
+     * @throws
+     */
+    add(local_name, remote_name) {
+        if(!local_name.match(/^[a-zA-Z0-9_$]+$/)) {
+            throw new Error(`Invalid import name: ${local_name}`)
+        }
+        if(!remote_name.match(/^[a-zA-Z0-9_$]+$/)) {
+            throw new Error(`Invalid export name: ${remote_name}`)
+        }
+        this.destToSrc[local_name] = remote_name
+    }
+    exportAll() {
+        return Object.keys(this.destToSrc).map(
+            k => `module.exports.ns.${k}=${this.destToSrc[k]}`
+        ).join(";")
+    }
+    /**
+     * Returns injectable source to export the given destination-to-source
+     * map of names from the given file.
+     *
+     * @param {string} file_quoted
+     * @return {string}
+     */
+    exportAllFrom(file_quoted) {
+        const local_names = Object.keys(this.destToSrc)
+        return `module.exports.exportFrom(require(${file_quoted}),{${local_names.map(name => `${name}:"${this.destToSrc[name]}"`).join(",")}})`
+    }
+    /**
+     * Returns injectable source to import the given destination-to-source
+     * map of names from the given file.
+     *
+     * @param {string} file_quoted
+     * @return {string}
+     */
+    importAllFrom(file_quoted) {
+        const local_names = Object.keys(this.destToSrc)
+        return `var ${local_names.join(",")};require(${file_quoted}).then(ns=>{${local_names.map(dest => `${dest}=ns.${this.destToSrc[dest]}`).join(";")}})`
+    }
+}

--- a/lib/identifier-list.js
+++ b/lib/identifier-list.js
@@ -47,7 +47,7 @@ module.exports = class IdentifierList {
      */
     exportAllFrom(file_quoted) {
         const local_names = Object.keys(this.destToSrc)
-        return `eximportBridge.exportFrom(require(${file_quoted}),{${local_names.map(name => `${name}:"${this.destToSrc[name]}"`).join(",")}})`
+        return `eximportBridge.exportFrom(require(${file_quoted})._bridge,{${local_names.map(name => `${name}:"${this.destToSrc[name]}"`).join(",")}})`
     }
     /**
      * Returns injectable source to import the given destination-to-source
@@ -58,6 +58,6 @@ module.exports = class IdentifierList {
      */
     importAllFrom(file_quoted) {
         const local_names = Object.keys(this.destToSrc)
-        return `var ${local_names.join(",")};require(${file_quoted}).then(ns=>{${local_names.map(dest => `${dest}=ns.${this.destToSrc[dest]}`).join(";")}})`
+        return `var ${local_names.join(",")};require(${file_quoted})._bridge.then(ns=>{${local_names.map(dest => `${dest}=ns.${this.destToSrc[dest]}`).join(";")}})`
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eximport",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Use ECMA6 import/export syntax from within NodeJS (simply require this module)",
   "main": "index.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {},
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node test.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eximport",
-  "version": "1.1.3",
+  "version": "2.0.0",
   "description": "Use ECMA6 import/export syntax from within NodeJS (simply require this module)",
   "main": "index.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Use ECMA6 import/export syntax from within NodeJS (simply require this module)",
   "main": "index.js",
   "dependencies": {
-    "eximport-bridge": "^1.0.0",
+    "eximport-bridge": "^1.1.0",
     "node-hook": "^0.4.0"
   },
   "devDependencies": {},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eximport",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Use ECMA6 import/export syntax from within NodeJS (simply require this module)",
   "main": "index.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eximport",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Use ECMA6 import/export syntax from within NodeJS (simply require this module)",
   "main": "index.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Use ECMA6 import/export syntax from within NodeJS (simply require this module)",
   "main": "index.js",
   "dependencies": {
-    "eximport-bridge": "^1.1.1",
+    "eximport-bridge": "^2.0.0",
     "node-hook": "^0.4.0"
   },
   "devDependencies": {},

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Use ECMA6 import/export syntax from within NodeJS (simply require this module)",
   "main": "index.js",
   "dependencies": {
+    "eximport-bridge": "git+https://github.com/jj101k/eximport-bridge.git",
     "node-hook": "^0.4.0"
   },
   "devDependencies": {},

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "import-export",
+  "name": "eximport",
   "version": "1.0.1",
   "description": "Use ECMA6 import/export syntax from within NodeJS (simply require this module)",
   "main": "index.js",
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Macmee/import-export.git"
+    "url": "https://github.com/jj101k/eximport.git"
   },
   "keywords": [
     "import",
@@ -24,7 +24,7 @@
   "author": "= <=> (=)",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/Macmee/import-export/issues"
+    "url": "https://github.com/jj101k/eximport/issues"
   },
-  "homepage": "https://github.com/Macmee/import-export"
+  "homepage": "https://github.com/jj101k/eximport"
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Use ECMA6 import/export syntax from within NodeJS (simply require this module)",
   "main": "index.js",
   "dependencies": {
-    "eximport-bridge": "^1.1.0",
+    "eximport-bridge": "^1.1.1",
     "node-hook": "^0.4.0"
   },
   "devDependencies": {},

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Use ECMA6 import/export syntax from within NodeJS (simply require this module)",
   "main": "index.js",
   "dependencies": {
-    "eximport-bridge": "git+https://github.com/jj101k/eximport-bridge.git",
+    "eximport-bridge": "^1.0.0",
     "node-hook": "^0.4.0"
   },
   "devDependencies": {},

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "ecma6",
     "commonjs"
   ],
-  "author": "= <=> (=)",
+  "author": "Jim Driscoll",
   "license": "ISC",
   "bugs": {
     "url": "https://github.com/jj101k/eximport/issues"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eximport",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Use ECMA6 import/export syntax from within NodeJS (simply require this module)",
   "main": "index.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eximport",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Use ECMA6 import/export syntax from within NodeJS (simply require this module)",
   "main": "index.js",
   "dependencies": {

--- a/test.js
+++ b/test.js
@@ -2,3 +2,4 @@ require("./index")
 require("./test/import")
 require("./test/circular-definition")
 require("./test/export-class").Baz.boz // Just try evaluating it
+require("./test/export-class").Baz.bar // Just try evaluating it

--- a/test.js
+++ b/test.js
@@ -7,3 +7,5 @@ require("./test/export-class").Baz.bar // Just try evaluating it
 require("./test/cycle-crash/t")
 require("./test/cycle-crash-wildcard/t")
 require("./test/late-reassign-wildcard/t")
+
+// require("./test/export-import-derived-mutual/t.js")

--- a/test.js
+++ b/test.js
@@ -5,6 +5,7 @@ require("./test/import")
 
 const a = require("./test/mutual-a")
 assert.ok(a.hasOwnProperty("A"), "mutual export is initially set")
+assert.equal(a.ab(), 69, "Circular definition works")
 const timeout = setTimeout(
     () => console.error("Passed timeout without import resolving - this is a bug"),
     5000

--- a/test.js
+++ b/test.js
@@ -1,2 +1,7 @@
-require("./index");
-require("./test/import");
+const assert = require("assert")
+
+require("./index")
+require("./test/import")
+
+const a = require("./test/mutual-a")
+assert.ok(a.hasOwnProperty("A"), "mutual export is initially set")

--- a/test.js
+++ b/test.js
@@ -1,0 +1,2 @@
+require("./index");
+require("./test/import");

--- a/test.js
+++ b/test.js
@@ -5,3 +5,16 @@ require("./test/import")
 
 const a = require("./test/mutual-a")
 assert.ok(a.hasOwnProperty("A"), "mutual export is initially set")
+const timeout = setTimeout(
+    () => console.error("Passed timeout without import resolving - this is a bug"),
+    5000
+)
+assert.doesNotReject(async () => {
+    try {
+        const ns = await a._bridge
+        assert.ok(ns.A, "mutual export is set to a real value after then()")
+    } catch(e) {
+        console.log(e)
+    }
+    clearTimeout(timeout)
+})

--- a/test.js
+++ b/test.js
@@ -3,3 +3,7 @@ require("./test/import")
 require("./test/circular-definition")
 require("./test/export-class").Baz.boz // Just try evaluating it
 require("./test/export-class").Baz.bar // Just try evaluating it
+
+require("./test/cycle-crash/t")
+require("./test/cycle-crash-wildcard/t")
+require("./test/late-reassign-wildcard/t")

--- a/test.js
+++ b/test.js
@@ -1,3 +1,4 @@
 require("./index")
 require("./test/import")
 require("./test/circular-definition")
+require("./test/export-class").Baz.boz // Just try evaluating it

--- a/test.js
+++ b/test.js
@@ -9,7 +9,9 @@ const timeout = setTimeout(
     () => console.error("Passed timeout without import resolving - this is a bug"),
     5000
 )
+let run_in_current_context = false
 assert.doesNotReject(async () => {
+    run_in_current_context = true
     try {
         const ns = await a._bridge
         assert.ok(ns.A, "mutual export is set to a real value after then()")
@@ -18,3 +20,4 @@ assert.doesNotReject(async () => {
     }
     clearTimeout(timeout)
 })
+assert.ok(run_in_current_context, "Resolveable dependencies complete in current context")

--- a/test.js
+++ b/test.js
@@ -1,24 +1,3 @@
-const assert = require("assert")
-
 require("./index")
 require("./test/import")
-
-const a = require("./test/mutual-a")
-assert.ok(a.hasOwnProperty("A"), "mutual export is initially set")
-assert.equal(a.ab(), 69, "Circular definition works")
-const timeout = setTimeout(
-    () => console.error("Passed timeout without import resolving - this is a bug"),
-    5000
-)
-let run_in_current_context = false
-assert.doesNotReject(async () => {
-    run_in_current_context = true
-    try {
-        const ns = await a._bridge
-        assert.ok(ns.A, "mutual export is set to a real value after then()")
-    } catch(e) {
-        console.log(e)
-    }
-    clearTimeout(timeout)
-})
-assert.ok(run_in_current_context, "Resolveable dependencies complete in current context")
+require("./test/circular-definition")

--- a/test/circular-definition.js
+++ b/test/circular-definition.js
@@ -1,0 +1,20 @@
+const assert = require("assert")
+const a = require("./mutual-a")
+assert.ok(a.hasOwnProperty("A"), "mutual export is initially set")
+assert.equal(a.ab(), 69, "Circular definition works")
+const timeout = setTimeout(
+    () => console.error("Passed timeout without import resolving - this is a bug"),
+    5000
+)
+let run_in_current_context = false
+assert.doesNotReject(async () => {
+    run_in_current_context = true
+    try {
+        const ns = await a._bridge
+        assert.ok(ns.A, "mutual export is set to a real value after then()")
+    } catch(e) {
+        console.log(e)
+    }
+    clearTimeout(timeout)
+})
+assert.ok(run_in_current_context, "Resolveable dependencies complete in current context")

--- a/test/circular-definition.js
+++ b/test/circular-definition.js
@@ -10,8 +10,7 @@ let run_in_current_context = false
 assert.doesNotReject(async () => {
     run_in_current_context = true
     try {
-        const ns = await a._bridge
-        assert.ok(ns.A, "mutual export is set to a real value after then()")
+        assert.ok(a.A, "mutual export is set to a real value")
     } catch(e) {
         console.log(e)
     }

--- a/test/cycle-crash-wildcard/a.js
+++ b/test/cycle-crash-wildcard/a.js
@@ -1,0 +1,6 @@
+import * as B from "./b"
+export class A {
+get b() {
+	return new B.B()
+}
+}

--- a/test/cycle-crash-wildcard/b.js
+++ b/test/cycle-crash-wildcard/b.js
@@ -1,0 +1,6 @@
+import * as C from "./c"
+export class B {
+get c() {
+	return new C.C()
+}
+}

--- a/test/cycle-crash-wildcard/c.js
+++ b/test/cycle-crash-wildcard/c.js
@@ -1,0 +1,6 @@
+import * as A from "./a"
+export class C extends A.A {
+get b() {
+	return 1
+}
+}

--- a/test/cycle-crash-wildcard/t.js
+++ b/test/cycle-crash-wildcard/t.js
@@ -1,3 +1,4 @@
-const A = require("./a")._bridge.ns.A
+const assert = require("assert")
+const A = require("./a").A
 const a = new A()
-console.log(a.b.c.b)
+assert.equal(a.b.c.b, 1)

--- a/test/cycle-crash-wildcard/t.js
+++ b/test/cycle-crash-wildcard/t.js
@@ -1,0 +1,3 @@
+const A = require("./a")._bridge.ns.A
+const a = new A()
+console.log(a.b.c.b)

--- a/test/cycle-crash/a.js
+++ b/test/cycle-crash/a.js
@@ -1,0 +1,6 @@
+import {B} from "./b"
+export class A {
+get b() {
+	return new B()
+}
+}

--- a/test/cycle-crash/b.js
+++ b/test/cycle-crash/b.js
@@ -1,0 +1,6 @@
+import { C } from "./c"
+export class B {
+get c() {
+	return new C()
+}
+}

--- a/test/cycle-crash/c.js
+++ b/test/cycle-crash/c.js
@@ -1,0 +1,6 @@
+import { A } from "./a"
+export class C extends A {
+get b() {
+	return 1
+}
+}

--- a/test/cycle-crash/t.js
+++ b/test/cycle-crash/t.js
@@ -1,3 +1,4 @@
-const A = require("./a")._bridge.ns.A
+const assert = require("assert")
+const A = require("./a").A
 const a = new A()
-console.log(a.b.c.b)
+assert.equal(a.b.c.b, 1)

--- a/test/cycle-crash/t.js
+++ b/test/cycle-crash/t.js
@@ -1,0 +1,3 @@
+const A = require("./a")._bridge.ns.A
+const a = new A()
+console.log(a.b.c.b)

--- a/test/export-class.js
+++ b/test/export-class.js
@@ -1,0 +1,6 @@
+export class Foo extends Error {}
+export class Baz {
+    static get boz() {
+        return new Foo("foo")
+    }
+}

--- a/test/export-class.js
+++ b/test/export-class.js
@@ -1,6 +1,10 @@
 export class Foo extends Error {}
+export var Foe = 1
 export class Baz {
     static get boz() {
         return new Foo("foo")
+    }
+    static get bar() {
+        return Foe.toFixed(2)
     }
 }

--- a/test/export-import-derived-mutual/bar.js
+++ b/test/export-import-derived-mutual/bar.js
@@ -1,0 +1,2 @@
+import {foo} from "./foo"
+export var bar = foo + 1

--- a/test/export-import-derived-mutual/foo.js
+++ b/test/export-import-derived-mutual/foo.js
@@ -1,0 +1,2 @@
+import "./bar" // for whatever reason
+export var foo = 41

--- a/test/export-import-derived-mutual/t.js
+++ b/test/export-import-derived-mutual/t.js
@@ -1,0 +1,3 @@
+const assert = require("assert")
+const bar = require("./bar")
+assert.equal(bar.bar, 42, "Exporting import-derived symbol through mutual dependency works")

--- a/test/export/a.js
+++ b/test/export/a.js
@@ -1,0 +1,5 @@
+var a=1, b=2, c=3, d=4;
+export { a, b };
+export { c as c1, d };
+
+export default 6 * 7;

--- a/test/export/b.js
+++ b/test/export/b.js
@@ -1,0 +1,6 @@
+export let e=5, f=6;
+export const g=7, h=8;
+
+export default function () { return 1 }
+
+export * from "./a";

--- a/test/export/c.js
+++ b/test/export/c.js
@@ -1,0 +1,10 @@
+export let i=9, j=10;
+export var k=11, l=12;
+
+export default class name1 {
+    static get foo() {
+        return 1;
+    }
+}
+
+export { e, h } from "./b";

--- a/test/export/d.js
+++ b/test/export/d.js
@@ -1,0 +1,8 @@
+export const m=14, n=15;
+
+var o = 16;
+var p = 17;
+
+export { o as default, p };
+
+export { i as eye, l } from "./c";

--- a/test/import.js
+++ b/test/import.js
@@ -1,55 +1,42 @@
-var assert = require("assert");
-import aDefault from "./export/a";
-assert.equal(
-    aDefault,
-    42,
-    "Static default import works"
-);
-import * as aAll from "./export/a";
+const assert = require("assert")
+import aDefault from "./export/a"
+assert.equal(aDefault, 42, "Static default import works")
+import * as aAll from "./export/a"
 assert.deepEqual(
     aAll,
-    { a: 1, b: 2, c1: 3, d: 4, default: 42 },
+    {a: 1, b: 2, c1: 3, d: 4, default: 42},
     "Namespaced wildcard import works with alias and expression default"
-);
-import { e } from "./export/b";
-assert.equal(
-    e,
-    5,
-    "Importing a named let item works"
-);
-import { c1 as see } from "./export/b";
+)
+import {e} from "./export/b"
+assert.equal(e, 5, "Importing a named let item works")
+import {c1 as see} from "./export/b"
 assert.equal(
     see,
     3,
     "Aliasing an imported item which was itself export-imported works"
-);
-import { k, l } from "./export/c";
+)
+import {k, l} from "./export/c"
 assert.deepEqual(
     [k, l],
     [11, 12],
     "Importing multiple named var items works"
-);
-import { h , e as eee } from "./export/c";
+)
+import {h , e as eee} from "./export/c"
 assert.deepEqual(
     [h, eee],
     [8, 5],
     "Importing multiple named items with alias and named export-import works"
-);
-import ooh, { m , n } from "./export/d";
+)
+import ooh, {m , n} from "./export/d"
 assert.deepEqual(
     [ooh, m, n],
-    [ 16, 14, 15 ],
+    [16, 14, 15],
     "Importing multiple named const items with named default export-import works"
 );
-import oh, * as dee from "./export/d";
+import oh, * as dee from "./export/d"
 assert.deepEqual(
     [oh, dee],
-    [ 16, { default: 16, p: 17, eye: 9, l: 12, m: 14, n: 15 } ],
+    [16, {default: 16, p: 17, eye: 9, l: 12, m: 14, n: 15}],
     "Namespaced import with default import works"
 )
-assert.doesNotThrow(
-    () => {
-        import "./export/d";
-    },
-    "Plain import for side-effects is accepted"
-);
+import "./export/d" /* Plain import for side-effects is accepted */

--- a/test/import.js
+++ b/test/import.js
@@ -1,0 +1,55 @@
+var assert = require("assert");
+import aDefault from "./export/a";
+assert.equal(
+    aDefault,
+    42,
+    "Static default import works"
+);
+import * as aAll from "./export/a";
+assert.deepEqual(
+    aAll,
+    { a: 1, b: 2, c1: 3, d: 4, default: 42 },
+    "Namespaced wildcard import works with alias and expression default"
+);
+import { e } from "./export/b";
+assert.equal(
+    e,
+    5,
+    "Importing a named let item works"
+);
+import { c1 as see } from "./export/b";
+assert.equal(
+    see,
+    3,
+    "Aliasing an imported item which was itself export-imported works"
+);
+import { k, l } from "./export/c";
+assert.deepEqual(
+    [k, l],
+    [11, 12],
+    "Importing multiple named var items works"
+);
+import { h , e as eee } from "./export/c";
+assert.deepEqual(
+    [h, eee],
+    [8, 5],
+    "Importing multiple named items with alias and named export-import works"
+);
+import ooh, { m , n } from "./export/d";
+assert.deepEqual(
+    [ooh, m, n],
+    [ 16, 14, 15 ],
+    "Importing multiple named const items with named default export-import works"
+);
+import oh, * as dee from "./export/d";
+assert.deepEqual(
+    [oh, dee],
+    [ 16, { default: 16, p: 17, eye: 9, l: 12, m: 14, n: 15 } ],
+    "Namespaced import with default import works"
+)
+assert.doesNotThrow(
+    () => {
+        import "./export/d";
+    },
+    "Plain import for side-effects is accepted"
+);

--- a/test/late-reassign-wildcard/a.js
+++ b/test/late-reassign-wildcard/a.js
@@ -1,0 +1,2 @@
+export var a = 1
+a = 2

--- a/test/late-reassign-wildcard/t.js
+++ b/test/late-reassign-wildcard/t.js
@@ -1,0 +1,2 @@
+const A = require("./a")._bridge.ns
+console.log(A.a)

--- a/test/late-reassign-wildcard/t.js
+++ b/test/late-reassign-wildcard/t.js
@@ -1,2 +1,3 @@
-const A = require("./a")._bridge.ns
-console.log(A.a)
+const assert = require("assert")
+const A = require("./a")
+assert.equal(A.a, 2)

--- a/test/mutual-a.js
+++ b/test/mutual-a.js
@@ -1,4 +1,4 @@
-import {B} from "./mutual-b"
+import {B, ba} from "./mutual-b"
 
 class A {
     b() {
@@ -6,3 +6,5 @@ class A {
     }
 }
 export {A}
+export var a = 42
+export function ab() {return ba() + 1}

--- a/test/mutual-a.js
+++ b/test/mutual-a.js
@@ -1,0 +1,8 @@
+import {B} from "./mutual-b"
+
+class A {
+    b() {
+        return new B()
+    }
+}
+export {A}

--- a/test/mutual-b.js
+++ b/test/mutual-b.js
@@ -1,0 +1,8 @@
+import {A} from "./mutual-a"
+
+class B {
+    a() {
+        return new A()
+    }
+}
+export {B}

--- a/test/mutual-b.js
+++ b/test/mutual-b.js
@@ -1,4 +1,4 @@
-import {A} from "./mutual-a"
+import {A, a} from "./mutual-a"
 
 class B {
     a() {
@@ -6,3 +6,4 @@ class B {
     }
 }
 export {B}
+export function ba() { return a + 26}


### PR DESCRIPTION
This adds support for `export {a, b}` and for patterns like `import {a, b} from "c"` (with double quotes). It also adds hoisting support by assigning the require return and deferring lookup of the actual names.

Caveats relating to hoisting:
- This assigns to a value which does not otherwise exist in the namespace. The value I've chosen ("imported") should be obvious enough that few will have a conflict. Other possible approaches would have been assigning one top-level variable per require (pollutes the namespace quite a lot, but would be potentially less likely to conflict), or to directly inject the require statement each time (no namespace presence).
- This replaces uses of the imported names in place. There will naturally be some false positives, for example if you're importing the symbol "Name", although if you're sticking to Javascript conventions (classes start with a capital, other stuff does not) and using sensible names this would be rare. If it were viable to crawl the AST looking for top-level namespace lookups, it could be done more reliably.
- Hoisting "default" would be extremely complex because the default names can't possibly be known until the given module has finished its require run. In principle you could use a deferred namespace injection callback, but that would mostly just make the code incomprehensible.


I've attached a simple example, which you can test with `node -r import-export c.js`.

[example.zip](https://github.com/Macmee/import-export/files/999545/example.zip)